### PR TITLE
元記事に存在していたリンクとスタイルをjupyterlite loves webassemblyの記事に追加しました。

### DIFF
--- a/jupyterlite-loves-webassembly.md
+++ b/jupyterlite-loves-webassembly.md
@@ -14,7 +14,7 @@ JupyterLiteはブラウザ内で動作する言語カーネルに支えられた
 ### モチベーション 
 
 <!-- JupyterLite is a reboot of several attempts at making a full static Jupyter distribution that runs in the browser, without having to start the Python Jupyter Server on the host machine, usually done by running jupyter lab or jupyter notebook in a terminal. -->
-JupyterLiteは、ブラウザ内で動作する完全な静的Jupyterディストリビューションを作る試みの仕切り直しになります。それは、通常ターミナルでjupyter labやjupyter notebookを実行することによって行われるホストマシン上のPythonのJupyterサーバーの起動を必要としません。
+JupyterLiteは、ブラウザ内で動作する完全な静的Jupyterディストリビューションを作る試みの仕切り直しになります。それは、通常ターミナルで`jupyter lab`や`jupyter notebook`を実行することによって行われるホストマシン上のPythonのJupyterサーバーの起動を必要としません。
 
 <!-- The goal of the project is to provide a lightweight computing environment accessible in a matter of seconds with a single click, in a web browser, and without having to install anything on the end-user device. -->
 プロジェクトの目標はエンドユーザーのデバイス上に何かをインストールさせる必要なく、シングルクリックで数秒のうちにアクセス可能となる軽量な計算機環境を供給することです。
@@ -34,7 +34,7 @@ ReadTheDocs上の静的なウェブサイトとしてブラウザ内で動作す
 JupyterLiteは、多くのJupyterLabのプラグインやコンポーネントをそのまま再利用できるよう新規に構築されています。
 
 <!-- In addition to JupyterLab, JupyterLite also includes the RetroLab interface by default: -->
-JupyterLabに加えて、JupyterLiteはRetroLabインタフェースをデフォルトで含んでいます。
+JupyterLabに加えて、JupyterLiteは[RetroLab](https://github.com/jupyterlab/retrolab)インタフェースをデフォルトで含んでいます。
 
 ![](https://miro.medium.com/max/1400/1*B1Se7Fe1JXBt2a1NjwRmxg.png)
 <!-- JupyterLite with the RetroLab interface -->
@@ -43,7 +43,7 @@ RetroLabインタフェースを備えたJupyterLite
 <!-- By reusing JupyterLab components, JupyterLite benefits from many of the upstream improvements such as new features, accessibility fixes, and upkeep improvements. 
 The recent work on real time collaboration coming in JupyterLab 3.1 and championed by Kevin Jahns, Carlos Herrero, and Eric Charles can be enabled in JupyterLite too! -->
 JupyterLabのコンポーネントを再利用することによって、JupyterLiteは新機能や、アクセシビリティの改善、メンテナンス面の改善のようなupstreamにおける多くの改善点の恩恵を受けることができます。
-Kevin Jahns, Carlos Herrero, Eric Charles によって支援された、JupyterLab 3.1で導入されるリアルタイムコラボレーションにおける最近の成果もJupyterLite内で有効化することができます！
+[Kevin Jahns](https://twitter.com/kevin_jahns), [Carlos Herrero](https://twitter.com/carlosHerreroB/), [Eric Charles](https://twitter.com/echarles)によって支援された、JupyterLab 3.1で導入される[リアルタイムコラボレーションにおける最近の成果](https://blog.jupyter.org/how-we-made-jupyter-notebooks-collaborative-with-yjs-b8dff6a9d8af?source=collection_home---6------0-----------------------)もJupyterLite内で有効化することができます！
 
 ![](https://miro.medium.com/max/1400/1*HwMx3Fd6iICkWjjvUCtvwA.gif)
 <!-- Real Time Collaboration with JupyterLite on ReadTheDocs -->
@@ -54,7 +54,7 @@ ReadTheDocs上で動作するJupyterLiteにおけるリアルタイムコラボ�
 
 <!-- Pyodide consists of the CPython 3.8 interpreter compiled to WebAssembly which allows Python to run in the browser. -->
 <!-- Many popular scientific Python packages have also been compiled and made available.  -->
-PyodideはPythonがブラウザ上で動作するようにWebAssemblyへとコンパイルされたCPython 3.8(訳注: 記事執筆時)のインタプリタを含んでいます。
+[Pyodide](https://pyodide.org/)はPythonがブラウザ上で動作するようにWebAssemblyへとコンパイルされたCPython 3.8(訳注: 記事執筆時)のインタプリタを含んでいます。
 多くのポピュラーな科学技術計算用のPythonパッケージについてもJupyterLiteで利用できるようにコンパイルされています。
 
 <!-- In addition, Pyodide can install any Python package with a pure Python wheel from the Python Package Index (PyPI). -->
@@ -68,18 +68,18 @@ PyodideはPythonパッケージのエコシステムをJavaScriptへと公開し
 Pyodide: WebAssemblyへとコンパイルされた科学技術計算スタックを備えたPython
 
 <!-- Currently at version 0.17, Pyodide has benefited from many improvements over the past years: smaller binary size, support for asyncio, and better type translations between Python and JavaScript. -->
-現在はバージョン0.17(訳注: 現在は0.21)であり、Pyodideは数年を経て多くの改善による恩恵(より小さなバイナリサイズ、asyncioのサポート、PythonとJavaScriptの間におけるより良い型変換、など)を受けてきています。
+現在は[バージョン0.17](https://hacks.mozilla.org/2021/04/pyodide-spin-out-and-0-17-release/)(訳注: 現在は0.21)であり、Pyodideは数年を経て多くの改善による恩恵(より小さなバイナリサイズ、asyncioのサポート、PythonとJavaScriptの間におけるより良い型変換、など)を受けてきています。
 
 <!-- JupyterLite ships by default with Pyolite, a Python kernel backed by Pyodide. Pyolite runs in a Web Worker and thus doesn’t block the main UI thread when intensive computations are executed. -->
-JupyterLiteはデフォルトでPyodideをバックエンドとしたPythonカーネルであるPyoliteとともに配布されます。
-PyoliteはWeb Worker内で動作するため、重たい計算が実行された場合においてもメインのUIスレッドをブロックすることはありません。
+JupyterLiteはデフォルトでPyodideをバックエンドとしたPythonカーネルである`Pyolite`とともに配布されます。
+Pyoliteは[Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API)内で動作するため、重たい計算が実行された場合においてもメインのUIスレッドをブロックすることはありません。
 
 <!-- ### IPython in the browser -->
 ### ブラウザ内におけるIPython
 
 <!-- Thanks to the work by Madhur Tandon in this pull request, Pyolite is now powered by IPython. -->
 <!-- This provides access to magics, code completion, rich display, interactive widgets, and many other features. -->
-[このプルリクエスト]()におけるMadhur Tandonの仕事のおかげで、PyoliteはIPythonの力によって動作するようになりました。
+[このプルリクエスト](https://github.com/jupyterlite/jupyterlite/pull/171)におけるMadhur Tandonの仕事のおかげで、PyoliteはIPythonの力によって動作するようになりました。
 これによりmagicコマンドやコード補完、リッチな表示、インタラクティブなウィジェット、そしてその他の多くの機能へのアクセスが提供されます。
 
 ![](https://miro.medium.com/max/1400/1*2WBnuwRGkASGVNYUGjyPHg.gif)
@@ -90,7 +90,7 @@ JupyterLiteでのIPythonの使用
 ### インタラクティブな可視化
 
 <!-- Many visualizations libraries such as Altair and Plotly are also supported in JupyterLite, allowing for quick and convenient figures and plots right in the browser: -->
-AltairやPlotlyのような多くの可視化ライブラリもJupyterLiteでサポートされており、ブラウザで素早く便利な図やプロットを作成できます。
+[Altair](https://altair-viz.github.io/)や[Plotly](https://plotly.com/)のような多くの可視化ライブラリもJupyterLiteでサポートされており、ブラウザで素早く便利な図やプロットを作成できます。
 
 ![](https://miro.medium.com/max/1400/1*SRr162bkckWsmoSMxVd2uQ.gif)
 <!-- Using Altair in JupyterLite -->
@@ -104,10 +104,10 @@ JupyterLiteでのPlotlyの図の作成
 ### Jupyterウィジェットのサポート
 
 <!-- Jupyter Widgets rely on the Custom Messages specification of the Jupyter Protocol to send messages back and forth between the kernel and the frontend. -->
-Jupyterウィジェットは、カーネルとフロントエンドの間でのメッセージのやり取りのためのJupyterプロトコルのカスタムメッセージ仕様に依存しています。
+Jupyterウィジェットは、カーネルとフロントエンドの間でのメッセージのやり取りのための[Jupyterプロトコルのカスタムメッセージ仕様](https://jupyter-client.readthedocs.io/en/latest/messaging.html#custom-messages)に依存しています。
 
 <!-- This pull request by Martin Renou added support for Comms in the Pyolite kernel, which enabled many of the existing core and third-party Jupyter Widgets to work out of the box in JupyterLite such as bqplot, ipyleaflet and ipycanvas. -->
-Martin RenouによるプルリクエストはPyoliteカーネルにおける通信サポートを追加し、bqplot, ipyleaflet, ipycanvasのような多くの既存のコアおよびサードパーティJupyterウィジェットをJupyterLiteですぐに使用できるようにしました。
+Martin Renouによる[このプルリクエスト](https://github.com/jupyterlite/jupyterlite/pull/145)はPyoliteカーネルにおける通信サポートを追加し、[bqplot](https://github.com/bqplot/bqplot), [ipyleaflet](https://github.com/jupyter-widgets/ipyleaflet), [ipycanvas](https://github.com/martinRenou/ipycanvas)のような多くの既存のコアおよびサードパーティJupyterウィジェットをJupyterLiteですぐに使用できるようにしました。
 
 ![](https://miro.medium.com/max/1400/1*c1DIbxS6bZ7bHDcOTEIJfg.gif)
 <!-- JupyterLite comes with support for Jupyter Widgets -->
@@ -117,7 +117,7 @@ Jupyterウィジェット対応を備えたJupyterLite
 ### 単なるPythonを超えて
 
 <!-- JupyterLite makes it possible to have plenty of other kernels also running in the browser. For now, the default distribution includes a JavaScript and a p5 kernel: -->
-JupyterLiteはその他多くのカーネルをブラウザ内で動作することを可能にしています。現在のところ、デフォルトのディストリビューションはJavaScriptとp5カーネルを含んでいます。
+JupyterLiteはその他多くのカーネルをブラウザ内で動作することを可能にしています。現在のところ、デフォルトのディストリビューションはJavaScriptと[p5](https://p5js.org/)カーネルを含んでいます。
 
 ![](https://miro.medium.com/max/1400/1*5XFdmBdQWeONbRD3nuQe0A.png)
 <!-- Multiple kernels are available in JupyterLite -->
@@ -137,7 +137,7 @@ JupyterLiteにおけるp5.jsカーネル
 既存のJupyterのツール群と同様に、JupyterLiteは必要に応じて簡単にカスタマイズできるように設定されています。
 
 <!-- It supports the new JupyterLab prebuilt extension system added to the 3.0 release. Existing JupyterLab extensions can then easily be reused in JupyterLite too! -->
-3.0のリリースでは新しいJupyterLabのprebuiltエクステンションシステムのサポートが追加されました。既存のJupyterLabのエクステンションは簡単にJupyterLiteでも再利用が可能です！
+3.0のリリースでは新しい[JupyterLabのprebuiltエクステンションシステム](https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html#prebuilt-extensions)のサポートが追加されました。既存のJupyterLabのエクステンションは簡単にJupyterLiteでも再利用が可能です！
 
 ![](https://miro.medium.com/max/1400/1*69CnccBrufVEEU0wqE_f7Q.gif)
 <!-- The JupyterLab Drawio extension running in JupyterLite -->
@@ -146,7 +146,7 @@ JupyterLiteで動作するJupyterLabのDrawioエクステンション
 <!-- The in-browser server part of JupyterLite also follows a plugin-based approach.
 The server is a Lumino application without a shell and registers multiple plugins such as kernels, the contents manager or the sessions service.  -->
 JupyterLiteのブラウザ内におけるサーバー部もプラグインベースのアプローチに従っています。
-そのサーバーはシェルを持たないLuminoアプリケーションであり、カーネルやコンテンツマネージャまたはセッションサービスのような複数のプラグインを登録します。
+そのサーバーはシェルを持たない[Lumino](https://github.com/jupyterlab/lumino)アプリケーションであり、カーネルやコンテンツマネージャまたはセッションサービスのような複数のプラグインを登録します。
 
 <!-- This plugin-based approach makes it very convenient for deployers and site administrators to swap a plugin for another one.  For instance, they might want to swap the default contents manager that stores notebooks and files in the browser local storage with another plugin that would save them on AWS S3 instead. -->
 このプラグインベースのアプローチはデプロイ実行者やサイト管理者がプラグインを入れ替えるのにとても便利です。
@@ -181,7 +181,7 @@ JupyterLiteは簡単に静的なウェブサイトとしてデプロイするこ
 ただユーザに静的ファイルを提供するための単純なHTTPサーバーがあれば良いのです。
 
 <!-- This simple approach makes it possible to use a variety of options: nginx, Binder, GitHub Pages or GitLab Pages, Vercel, Netlify, and more. It can even be deployed to ReadTheDocs, which is where the default JupyterLite demo site is hosted and continuously updated. -->
-このシンプルなアプローチは(デプロイ先として)様々な選択を行うことが可能となります、例えばnginx, Binder, GitHub Pages, GitLab Pages, Vercel, Netlifyなどが考えられます。
+このシンプルなアプローチは(デプロイ先として)様々な選択を行うことが可能となります、例えばnginx, [Binder](https://mybinder.org/), GitHub Pages, GitLab Pages, Vercel, Netlifyなどが考えられます。
 ReadTheDocsへとデプロイすることさえ可能であり、ReadTheDocsには(実際に)デフォルトのJupyterLiteのデモサイトがホストされ、継続的に更新されています。
 
 <!-- Many of the deployment scenarios are already documented in https://jupyterlite.readthedocs.io/en/latest/deploying.html. There is also a demo template to easily deploy a custom JupyterLite website on GitHub Pages with a single click: https://github.com/jupyterlite/demo -->
@@ -189,11 +189,11 @@ https://jupyterlite.readthedocs.io/en/latest/deploying.html には多くのデ�
 https://github.com/jupyterlite/demo にはシングルクリックでGitHub PagesにカスタマイズされたJupyterLiteのウェブサイトを簡単にデプロイするためのデモテンプレートも存在しています。
 
 <!-- Thanks to the work by Nicholas Bollweg in this pull request, JupyterLite now offers a jupyterlite command line tool to make custom deployments much more convenient. -->
-Nicholas Bollwegのこのプルリクエストにおける仕事のおかげで、今やJupyterLiteはカスタムデプロイを更に便利にするためのjupyterliteコマンドラインツールを提供しています。
+Nicholas Bollwegの[このプルリクエスト](https://github.com/jupyterlite/jupyterlite/pull/147)における仕事のおかげで、今やJupyterLiteはカスタムデプロイを更に便利にするための`jupyterlite`[コマンドラインツール](https://pypi.org/project/jupyterlite/)を提供しています。
 
 <!-- One of the goals of JupyterLite is to let anyone build their custom distribution with the set of plugins and extensions they would like to use. For now, it requires using the jupyterlite CLI, but we can imagine having a more user-friendly way of exporting a custom JupyterLite website. -->
 JupyterLiteの目標の一つとして、使いたいプラグインやエクステンションのセットでカスタマイズしたディトリビューションを誰でもビルドできるようにする、ということがあります。
-今のところjupyterlite CLIを用いることが必要ではありますが、カスタマイズされたJupyterLiteウェブサイトをエクスポートする方法の、更にユーザーフレンドリーなものを想像できます。
+今のところ`jupyterlite` CLIを用いることが必要ではありますが、カスタマイズされたJupyterLiteウェブサイトをエクスポートする方法の、更にユーザーフレンドリーなものを想像できます。
 
 ![](https://miro.medium.com/max/1400/1*LL_UkItjshAzsEEDB4cI2A.png)
 <!-- A mock-up for the JupyterLite Exporter -->
@@ -213,7 +213,7 @@ JupyterLite Exporterに対するモックアップ
 JupyterLiteがあれば我々はJupyterユーザの次の波が起こることも期待でき、新規参入者や幅広いコミュニティが全てのエコシステムに更にアクセスしやすくなることが期待できます。
 
 <!-- For simpler and smaller-scale projects, it could even help reduce the load on mybinder.org by having a “binderlite” version of JupyterLite deployed on a CDN. -->
-より単純で小規模なスケールのプロジェクトに対しては、CDNにデプロイされたJupyterLiteの'binderlite'バージョンを作成することによってmybinder.orgの負荷を下げることもできると思われます。
+より単純で小規模なスケールのプロジェクトに対しては、CDNにデプロイされた[JupyterLiteの'binderlite'バージョン](https://twitter.com/fperez_org/status/1385825172230262794)を作成することによって[mybinder.org](https://mybinder.org/)の負荷を下げることもできると思われます。
 
 <!-- ### Try it online -->
 ### オンラインで試してみよう
@@ -261,8 +261,8 @@ JupyterLiteはまだまだ活発に開発されている状態であり、多く
 * Provide more user-friendly tools to easily export a custom JupyterLite distribution.
 -->
 * JupyterLabのfederated (prebuilt) エクステンションシステムを再利用して、カスタムのブラウザー内カーネルを作成するためのツールの改良
-* mambaとconda-forgeのインフラを活用することによるPyodideにおけるパッケージ管理の仕組みの改善
-* VoilàやGator、Quetzフロントエンドといった他のlabベースのアプリケーション内でのJupyterLiteパッケージの再利用
+* [mamba](https://github.com/mamba-org/mamba)と[conda-forgeのインフラ](https://github.com/conda-forge/conda-forge.github.io/issues/1401)を活用することによるPyodideにおけるパッケージ管理の仕組みの改善
+* [Voilà](https://github.com/voila-dashboards/voila)や[Gator](https://github.com/mamba-org/gator)、[Quetzフロントエンド](https://github.com/mamba-org/quetz-frontend)といった他のlabベースのアプリケーション内でのJupyterLiteパッケージの再利用
 * カスタムJupyterLiteディストリビューションを簡単にエクスポートできる、よりユーザーフレンドリなツールの提供
 
 <!-- ### Getting involved -->
@@ -280,26 +280,26 @@ JupyterLiteは活発な開発が下記で行われています。
 ### 著者について
 
 <!-- Jeremy Tuloup is a Scientific Software Developer at QuantStack and a Jupyter Distinguished Contributor. Maintainer and contributor of JupyterLab, Voilà, and many projects within the Jupyter ecosystem. -->
-Jeremy TuloupはQuantStackで働く科学技術ソフトウェア開発者でありJupyterへの功績が際だったコントリビュータです。
+[Jeremy Tuloup](https://twitter.com/jtpio)は[QuantStack](https://twitter.com/QuantStack)で働く科学技術ソフトウェア開発者でありJupyterへの功績が際だったコントリビュータです。
 また、 JupyterLabやVoilà、Jupyterのエコシステムに含まれる多くのプロジェクトのメンテナかつコントリビュータでもあります。
 
 <!-- ### Acknowledgments -->
 ### 謝辞
 
 <!-- We would like to acknowledge the previous work and the contributors who have worked on exploring the idea of Python in the notebook before us: Jyve, the Iodide notebook, Basthon, and the p5 notebook.  -->
-Jyve, Iodide notebook、Basthon、p5 notebookといった、私たちの前にノートブックにおけるPythonに関するアイデアの探求に邁進してきた過去の仕事やコントリビュータに感謝を示します。
+[Jyve](https://github.com/deathbeds/jyve), [Iodide notebook](https://github.com/iodide-project/iodide)、[Basthon](https://basthon.fr/)、[p5 notebook](https://github.com/jtpio/p5-notebook)といった、私たちの前にノートブックにおけるPythonに関するアイデアの探求に邁進してきた過去の仕事やコントリビュータに感謝を示します。
 
 <!-- It is also worth mentioning that similar projects exist outside of the Jupyter ecosystem, such as Observable and the Starboard Notebook. -->
-またJupyterエコシステムの外部に存在する、ObservableやStarboard Notebookといった同様のプロジェクトについても言及する価値があります。
+またJupyterエコシステムの外部に存在する、[Observable](https://observablehq.com/)や[Starboard Notebook](https://starboard.gg/)といった同様のプロジェクトについても言及する価値があります。
 
 <!-- We are grateful to Nicholas Bollweg, Madhur Tandon, Martin Renou for their contributions to JupyterLite, to Roman Yurchak and team for the work on Pyodide, Romain Casati for developing the Basthon kernel. -->
-Nicholas Bollweg, Madhur Tandon, Martin Renou に対してJupyterLiteへのコントリビューションに感謝します。
-Roman Yurchakとそのチームに対してPyodideの成果に感謝します。
+[Nicholas Bollweg](https://github.com/bollwyvl), [Madhur Tandon](https://twitter.com/mad_tandon), [Martin Renou](https://twitter.com/martinRenou) に対してJupyterLiteへのコントリビューションに感謝します。
+[Roman Yurchak](https://twitter.com/RomanYurchak)とそのチームに対してPyodideの成果に感謝します。
 Romain Casatiに対してBasthonカーネルの開発について感謝します。
 
 
 <!-- The work on JupyterLite by Jeremy Tuloup, Madhur Tandon, and Martin Renou was funded by QuantStack. -->
-Jeremy Tuloup, Madhur Tandon, Martin Renou によるJupyterLiteの仕事はQuantStackによる支援を受けています。
+Jeremy Tuloup, Madhur Tandon, Martin Renou によるJupyterLiteの仕事は[QuantStack](https://twitter.com/QuantStack)による支援を受けています。
 
 ![](https://miro.medium.com/max/1400/1*UY4k_mgLml9uvyo_EKMdFA.png)
 


### PR DESCRIPTION
件名の通りであり、特に問題ないと思われるためプルリクエスト作成後にマージします。
Mediumには折を見て反映させます。